### PR TITLE
Add Room 427 Gazebo world

### DIFF
--- a/Projects/gazebo_demo/models/moein_fluorescent_ceiling_light/model.config
+++ b/Projects/gazebo_demo/models/moein_fluorescent_ceiling_light/model.config
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<model>
+  <name>moein_fluorescent_ceiling_light</name>
+  <version>1.0</version>
+  <sdf version="1.10">model.sdf</sdf>
+  <author>
+    <name>Moein</name>
+    <email>none</email>
+  </author>
+  <description>
+    Reusable fluorescent ceiling light model with real panel dimensions and downward spot light.
+  </description>
+</model>

--- a/Projects/gazebo_demo/models/moein_fluorescent_ceiling_light/model.sdf
+++ b/Projects/gazebo_demo/models/moein_fluorescent_ceiling_light/model.sdf
@@ -1,0 +1,52 @@
+<?xml version="1.0" ?>
+<sdf version="1.10">
+  <model name="moein_fluorescent_ceiling_light">
+    <static>true</static>
+
+    <link name="panel_link">
+      <pose>0 0 0 0 0 0</pose>
+
+      <collision name="panel_collision">
+        <geometry>
+          <box>
+            <size>1.2 0.3 0.05</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <visual name="panel_visual">
+        <pose>0 0 -0.025 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>1.2 0.3 0.05</size>
+          </box>
+        </geometry>
+        <material>
+          <ambient>0.2 0.2 0.2 1</ambient>
+          <diffuse>1 1 1 1</diffuse>
+          <emissive>0.8 0.8 0.7 1</emissive>
+          <specular>0.2 0.2 0.2 1</specular>
+        </material>
+      </visual>
+
+      <light name="panel_light" type="spot">
+        <pose>0 0 -0.03 0 0 0</pose>
+        <diffuse>1.0 0.98 0.9 1</diffuse>
+        <specular>0.5 0.5 0.5 1</specular>
+        <attenuation>
+          <range>10</range>
+          <constant>0.8</constant>
+          <linear>0.2</linear>
+          <quadratic>0.02</quadratic>
+        </attenuation>
+        <direction>0 0 -1</direction>
+        <spot>
+          <inner_angle>0.9</inner_angle>
+          <outer_angle>1.2</outer_angle>
+          <falloff>0.5</falloff>
+        </spot>
+        <cast_shadows>true</cast_shadows>
+      </light>
+    </link>
+  </model>
+</sdf>

--- a/Projects/gazebo_demo/models/moein_room_427_shell/model.config
+++ b/Projects/gazebo_demo/models/moein_room_427_shell/model.config
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<model>
+  <name>moein_room_427_shell</name>
+  <version>1.0</version>
+  <sdf version="1.10">model.sdf</sdf>
+  <author>
+    <name>Moein</name>
+    <email>none</email>
+  </author>
+  <description>
+    Reusable Room 427 shell model containing floor, walls, windows, doors, and connected 3-box section.
+  </description>
+</model>

--- a/Projects/gazebo_demo/models/moein_room_427_shell/model.sdf
+++ b/Projects/gazebo_demo/models/moein_room_427_shell/model.sdf
@@ -1,0 +1,672 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sdf version="1.10">
+  <model name="moein_room_427_shell">
+    <static>true</static>
+    <model name="room_427_floor">
+      <static>true</static>
+      <pose>12.1 3.27 0 0 0 0</pose>
+      <link name="floor_link">
+        <collision name="floor_collision">
+          <geometry>
+            <box>
+              <size>24.2 6.54 0.03</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="floor_visual">
+          <geometry>
+            <box>
+              <size>24.2 6.54 0.03</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.01 0.01 0.01 1</ambient>
+            <diffuse>0.02 0.02 0.02 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            <pbr>
+              <metal>
+                <metalness>0.0</metalness>
+                <roughness>0.18</roughness>
+              </metal>
+            </pbr>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <model name="back_wall_D_C">
+      <static>true</static>
+      <pose>12.1 6.54 1.375 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>24.2 0.12 2.75</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>24.2 0.12 2.75</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.62 0.62 0.62 1</ambient>
+            <diffuse>0.62 0.62 0.62 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <model name="wall_A_C_solid_no_door">
+      <static>true</static>
+      <pose>24.2 3.27 1.375 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.12 6.54 2.75</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.12 6.54 2.75</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.75 0.75 0.75 1</ambient>
+            <diffuse>0.75 0.75 0.75 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <model name="B_D_wall_solid_with_door3_panel">
+      <static>true</static>
+      <pose>0 3.27 1.375 0 0 0</pose>
+      <link name="wall_B_D_solid">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.12 6.54 2.75</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.12 6.54 2.75</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.75 0.75 0.75 1</ambient>
+            <diffuse>0.75 0.75 0.75 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="door_3_panel_near_D">
+        <pose>0.065 1.5682 -0.16 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.04 0.9144 2.43</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.45 0.45 0.45 1</ambient>
+            <diffuse>0.45 0.45 0.45 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <model name="window_wall_lower_A_B">
+      <static>true</static>
+      <pose>12.1 0 0.545 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>24.2 0.12 1.09</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>24.2 0.12 1.09</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <model name="window_wall_top_A_B">
+      <static>true</static>
+      <pose>12.1 0 2.5925 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>24.2 0.12 0.305</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>24.2 0.12 0.305</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <model name="window_wall_vertical_pieces">
+      <static>true</static>
+      <link name="window_side_left">
+        <pose>0.1725 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.345 0.12 1.35</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.345 0.12 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="window_gap_1">
+        <pose>2.97 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="window_gap_2">
+        <pose>6.01 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="window_gap_3">
+        <pose>9.05 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="window_gap_4">
+        <pose>12.09 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="window_gap_5">
+        <pose>15.13 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="window_gap_6">
+        <pose>18.17 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="window_gap_7">
+        <pose>21.21 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.83 0.12 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="window_side_right">
+        <pose>24.0175 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.365 0.12 1.35</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.365 0.12 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <model name="window_glass_panes">
+      <static>true</static>
+      <link name="window_1">
+        <pose>1.45 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.21 0.03 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+      <link name="window_2">
+        <pose>4.49 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.21 0.03 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+      <link name="window_3">
+        <pose>7.53 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.21 0.03 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+      <link name="window_4">
+        <pose>10.57 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.21 0.03 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+      <link name="window_5">
+        <pose>13.61 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.21 0.03 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+      <link name="window_6">
+        <pose>16.65 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.21 0.03 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+      <link name="window_7">
+        <pose>19.69 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.21 0.03 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+      <link name="window_8">
+        <pose>22.73 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>2.21 0.03 1.35</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+    </model>
+    <model name="doors_and_connected_boxes_on_D_C_wall">
+      <static>true</static>
+      <link name="door_1_panel_D_C_wall">
+        <pose>21.7 6.47 1.215 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1.72 0.04 2.43</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.45 0.45 0.45 1</ambient>
+            <diffuse>0.45 0.45 0.45 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="door_2_panel_D_C_wall">
+        <pose>14.0 6.47 1.215 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1.83 0.04 2.43</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.45 0.45 0.45 1</ambient>
+            <diffuse>0.45 0.45 0.45 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="boxes_back_wall">
+        <pose>11.1 6.27 1.375 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>4.699 0.12 2.75</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>4.699 0.12 2.75</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.85 0.85 0.85 1</ambient>
+            <diffuse>0.85 0.85 0.85 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="boxes_left_side">
+        <pose>8.75 5.50 1.375 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.127 1.549 2.75</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.127 1.549 2.75</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.85 0.85 0.85 1</ambient>
+            <diffuse>0.85 0.85 0.85 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="boxes_divider_1">
+        <pose>10.27 5.50 1.375 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.127 1.549 2.75</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.127 1.549 2.75</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.85 0.85 0.85 1</ambient>
+            <diffuse>0.85 0.85 0.85 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="boxes_divider_2">
+        <pose>11.79 5.50 1.375 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.127 1.549 2.75</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.127 1.549 2.75</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.85 0.85 0.85 1</ambient>
+            <diffuse>0.85 0.85 0.85 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="boxes_right_side">
+        <pose>13.45 5.50 1.375 0 0 0</pose>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.127 1.549 2.75</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.127 1.549 2.75</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.85 0.85 0.85 1</ambient>
+            <diffuse>0.85 0.85 0.85 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="box_1_blue_panel">
+        <pose>9.51 6.20 1.35 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1.397 0.03 2.50</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.0 0.16 0.35 1</ambient>
+            <diffuse>0.0 0.16 0.35 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="box_2_blue_panel">
+        <pose>11.03 6.20 1.35 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1.397 0.03 2.50</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.0 0.16 0.35 1</ambient>
+            <diffuse>0.0 0.16 0.35 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="box_3_blue_panel">
+        <pose>12.55 6.20 1.35 0 0 0</pose>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1.397 0.03 2.50</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.0 0.16 0.35 1</ambient>
+            <diffuse>0.0 0.16 0.35 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+  </model>
+</sdf>

--- a/Projects/gazebo_demo/worlds/427.world
+++ b/Projects/gazebo_demo/worlds/427.world
@@ -1,0 +1,1539 @@
+<?xml version="1.0" ?>
+<sdf version="1.10">
+  <world name="room_427">
+
+    <plugin filename="gz-sim-physics-system" name="gz::sim::systems::Physics"/>
+    <plugin filename="gz-sim-user-commands-system" name="gz::sim::systems::UserCommands"/>
+    <plugin filename="gz-sim-scene-broadcaster-system" name="gz::sim::systems::SceneBroadcaster"/>
+
+    <gravity>0 0 -9.8</gravity>
+
+    <scene>
+      <ambient>0.45 0.45 0.45 1</ambient>
+      <background>0.75 0.78 0.82 1</background>
+      <shadows>true</shadows>
+      <grid>false</grid>
+    </scene>
+
+    <light name="main_light" type="directional">
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.4 0.4 0.4 1</specular>
+      <direction>-0.5 0.5 -1</direction>
+    </light>
+
+    <gui fullscreen="0">
+      <camera name="user_camera">
+        <pose>12 -10 8 0.7 0 1.15</pose>
+      </camera>
+    </gui>
+
+    <!-- Floor: black, reflective -->
+    <model name="room_427_floor">
+      <static>true</static>
+      <pose>12.1 3.27 0 0 0 0</pose>
+      <link name="floor_link">
+        <collision name="floor_collision">
+          <geometry><box><size>24.2 6.54 0.03</size></box></geometry>
+        </collision>
+        <visual name="floor_visual">
+          <geometry><box><size>24.2 6.54 0.03</size></box></geometry>
+          <material>
+            <ambient>0.01 0.01 0.01 1</ambient>
+            <diffuse>0.02 0.02 0.02 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            <pbr>
+              <metal>
+                <metalness>0.0</metalness>
+                <roughness>0.18</roughness>
+              </metal>
+            </pbr>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="back_wall_D_C">
+      <static>true</static>
+      <pose>12.1 6.54 1.375 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry><box><size>24.2 0.12 2.75</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>24.2 0.12 2.75</size></box></geometry>
+          <material>
+            <ambient>0.62 0.62 0.62 1</ambient>
+            <diffuse>0.62 0.62 0.62 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+    </model>
+
+    <model name="wall_A_C_solid_no_door">
+      <static>true</static>
+      <pose>24.2 3.27 1.375 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry><box><size>0.12 6.54 2.75</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.12 6.54 2.75</size></box></geometry>
+          <material>
+            <ambient>0.75 0.75 0.75 1</ambient>
+            <diffuse>0.75 0.75 0.75 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+    </model>
+    <!-- B-D wall: solid wall; Door 3 is shown as a gray door panel near D -->
+    <model name="B_D_wall_solid_with_door3_panel">
+      <static>true</static>
+      <pose>0 3.27 1.375 0 0 0</pose>
+      <link name="wall_B_D_solid">
+        <collision name="collision">
+          <geometry><box><size>0.12 6.54 2.75</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.12 6.54 2.75</size></box></geometry>
+          <material>
+            <ambient>0.75 0.75 0.75 1</ambient>
+            <diffuse>0.75 0.75 0.75 1</diffuse>
+          </material>
+        </visual>
+      </link>
+      <link name="door_3_panel_near_D">
+        <pose>0.065 1.5682 -0.16 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.04 0.9144 2.43</size></box></geometry>
+          <material>
+            <ambient>0.45 0.45 0.45 1</ambient>
+            <diffuse>0.45 0.45 0.45 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="window_wall_lower_A_B">
+      <static>true</static>
+      <pose>12.1 0 0.545 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry><box><size>24.2 0.12 1.09</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>24.2 0.12 1.09</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+    </model>
+
+    <model name="window_wall_top_A_B">
+      <static>true</static>
+      <pose>12.1 0 2.5925 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry><box><size>24.2 0.12 0.305</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>24.2 0.12 0.305</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+    </model>
+
+    <model name="window_wall_vertical_pieces">
+      <static>true</static>
+
+      <link name="window_side_left">
+        <pose>0.1725 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.345 0.12 1.35</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.345 0.12 1.35</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="window_gap_1">
+        <pose>2.97 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="window_gap_2">
+        <pose>6.01 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="window_gap_3">
+        <pose>9.05 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="window_gap_4">
+        <pose>12.09 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="window_gap_5">
+        <pose>15.13 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="window_gap_6">
+        <pose>18.17 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="window_gap_7">
+        <pose>21.21 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.83 0.12 1.35</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="window_side_right">
+        <pose>24.0175 0 1.765 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.365 0.12 1.35</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.365 0.12 1.35</size></box></geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+    </model>
+
+    <model name="window_glass_panes">
+      <static>true</static>
+
+      <link name="window_1">
+        <pose>1.45 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>2.21 0.03 1.35</size></box></geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            
+            
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+
+      <link name="window_2">
+        <pose>4.49 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>2.21 0.03 1.35</size></box></geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            
+            
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+
+      <link name="window_3">
+        <pose>7.53 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>2.21 0.03 1.35</size></box></geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            
+            
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+
+      <link name="window_4">
+        <pose>10.57 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>2.21 0.03 1.35</size></box></geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            
+            
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+
+      <link name="window_5">
+        <pose>13.61 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>2.21 0.03 1.35</size></box></geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            
+            
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+
+      <link name="window_6">
+        <pose>16.65 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>2.21 0.03 1.35</size></box></geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            
+            
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+
+      <link name="window_7">
+        <pose>19.69 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>2.21 0.03 1.35</size></box></geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            
+            
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+
+      <link name="window_8">
+        <pose>22.73 -0.07 1.765 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>2.21 0.03 1.35</size></box></geometry>
+          <material>
+            <ambient>0.55 0.75 0.9 0.35</ambient>
+            <diffuse>0.55 0.75 0.9 0.35</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+            
+            
+          </material>
+          <transparency>0.55</transparency>
+        </visual>
+      </link>
+    </model>
+
+    <model name="ceiling_lights_zone1">
+      <static>true</static>
+
+      <link name="ceiling_lights_zone1_r1_c1">
+        <pose>1.8 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r1_c2">
+        <pose>1.8 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r1_c3">
+        <pose>1.8 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r1_c4">
+        <pose>1.8 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r2_c1">
+        <pose>3.0 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r2_c2">
+        <pose>3.0 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r2_c3">
+        <pose>3.0 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r2_c4">
+        <pose>3.0 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r3_c1">
+        <pose>4.2 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r3_c2">
+        <pose>4.2 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r3_c3">
+        <pose>4.2 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r3_c4">
+        <pose>4.2 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r4_c1">
+        <pose>5.4 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r4_c2">
+        <pose>5.4 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r4_c3">
+        <pose>5.4 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone1_r4_c4">
+        <pose>5.4 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+    </model>
+
+    <model name="ceiling_lights_zone2">
+      <static>true</static>
+
+      <link name="ceiling_lights_zone2_r1_c1">
+        <pose>8.0 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r1_c2">
+        <pose>8.0 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r1_c3">
+        <pose>8.0 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r2_c1">
+        <pose>9.4 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r2_c2">
+        <pose>9.4 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r2_c3">
+        <pose>9.4 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r3_c1">
+        <pose>10.8 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r3_c2">
+        <pose>10.8 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r3_c3">
+        <pose>10.8 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r4_c1">
+        <pose>12.2 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r4_c2">
+        <pose>12.2 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone2_r4_c3">
+        <pose>12.2 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+    </model>
+
+    <model name="ceiling_lights_zone3">
+      <static>true</static>
+
+      <link name="ceiling_lights_zone3_r1_c1">
+        <pose>14.2 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r1_c2">
+        <pose>14.2 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r1_c3">
+        <pose>14.2 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r1_c4">
+        <pose>14.2 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r2_c1">
+        <pose>15.4 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r2_c2">
+        <pose>15.4 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r2_c3">
+        <pose>15.4 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r2_c4">
+        <pose>15.4 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r3_c1">
+        <pose>16.6 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r3_c2">
+        <pose>16.6 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r3_c3">
+        <pose>16.6 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r3_c4">
+        <pose>16.6 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r4_c1">
+        <pose>17.8 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r4_c2">
+        <pose>17.8 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r4_c3">
+        <pose>17.8 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r4_c4">
+        <pose>17.8 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r5_c1">
+        <pose>19.0 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r5_c2">
+        <pose>19.0 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r5_c3">
+        <pose>19.0 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r5_c4">
+        <pose>19.0 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r6_c1">
+        <pose>20.2 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r6_c2">
+        <pose>20.2 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r6_c3">
+        <pose>20.2 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r6_c4">
+        <pose>20.2 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r7_c1">
+        <pose>21.4 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r7_c2">
+        <pose>21.4 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r7_c3">
+        <pose>21.4 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r7_c4">
+        <pose>21.4 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r8_c1">
+        <pose>22.6 0.75 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r8_c2">
+        <pose>22.6 2.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r8_c3">
+        <pose>22.6 4.15 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="ceiling_lights_zone3_r8_c4">
+        <pose>22.6 5.55 2.70 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>0.85 0.32 0.04</size></box></geometry>
+          <material>
+            <ambient>1.0 0.92 0.7 1</ambient>
+            <diffuse>1.0 0.92 0.7 1</diffuse>
+            
+            <emissive>1.0 0.92 0.7 1</emissive>
+            
+          </material>
+          
+        </visual>
+      </link>
+    </model>
+
+    <model name="doors_and_connected_boxes_on_D_C_wall">
+      <static>true</static>
+
+      <link name="door_1_panel_D_C_wall">
+        <pose>21.7 6.47 1.215 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>1.72 0.04 2.43</size></box></geometry>
+          <material>
+            <ambient>0.45 0.45 0.45 1</ambient>
+            <diffuse>0.45 0.45 0.45 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="door_2_panel_D_C_wall">
+        <pose>14.0 6.47 1.215 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>1.83 0.04 2.43</size></box></geometry>
+          <material>
+            <ambient>0.45 0.45 0.45 1</ambient>
+            <diffuse>0.45 0.45 0.45 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="boxes_back_wall">
+        <pose>11.1 6.27 1.375 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>4.699 0.12 2.75</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>4.699 0.12 2.75</size></box></geometry>
+          <material>
+            <ambient>0.85 0.85 0.85 1</ambient>
+            <diffuse>0.85 0.85 0.85 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="boxes_left_side">
+        <pose>8.75 5.50 1.375 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.127 1.549 2.75</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.127 1.549 2.75</size></box></geometry>
+          <material>
+            <ambient>0.85 0.85 0.85 1</ambient>
+            <diffuse>0.85 0.85 0.85 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="boxes_divider_1">
+        <pose>10.27 5.50 1.375 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.127 1.549 2.75</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.127 1.549 2.75</size></box></geometry>
+          <material>
+            <ambient>0.85 0.85 0.85 1</ambient>
+            <diffuse>0.85 0.85 0.85 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="boxes_divider_2">
+        <pose>11.79 5.50 1.375 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.127 1.549 2.75</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.127 1.549 2.75</size></box></geometry>
+          <material>
+            <ambient>0.85 0.85 0.85 1</ambient>
+            <diffuse>0.85 0.85 0.85 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="boxes_right_side">
+        <pose>13.45 5.50 1.375 0 0 0</pose>
+        <collision name="collision">
+          <geometry><box><size>0.127 1.549 2.75</size></box></geometry>
+        </collision>
+        <visual name="visual">
+          <geometry><box><size>0.127 1.549 2.75</size></box></geometry>
+          <material>
+            <ambient>0.85 0.85 0.85 1</ambient>
+            <diffuse>0.85 0.85 0.85 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="box_1_blue_panel">
+        <pose>9.51 6.20 1.35 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>1.397 0.03 2.50</size></box></geometry>
+          <material>
+            <ambient>0.0 0.16 0.35 1</ambient>
+            <diffuse>0.0 0.16 0.35 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="box_2_blue_panel">
+        <pose>11.03 6.20 1.35 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>1.397 0.03 2.50</size></box></geometry>
+          <material>
+            <ambient>0.0 0.16 0.35 1</ambient>
+            <diffuse>0.0 0.16 0.35 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+
+      <link name="box_3_blue_panel">
+        <pose>12.55 6.20 1.35 0 0 0</pose>
+        <visual name="visual">
+          <geometry><box><size>1.397 0.03 2.50</size></box></geometry>
+          <material>
+            <ambient>0.0 0.16 0.35 1</ambient>
+            <diffuse>0.0 0.16 0.35 1</diffuse>
+            
+            
+            
+          </material>
+          
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/Projects/gazebo_demo/worlds/427_reusable.world
+++ b/Projects/gazebo_demo/worlds/427_reusable.world
@@ -1,0 +1,403 @@
+<?xml version="1.0" ?>
+<sdf version="1.10">
+  <world name="room_427_reusable">
+
+    <plugin filename="gz-sim-physics-system"
+            name="gz::sim::systems::Physics"/>
+    <plugin filename="gz-sim-user-commands-system"
+            name="gz::sim::systems::UserCommands"/>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+            name="gz::sim::systems::SceneBroadcaster"/>
+
+    <gravity>0 0 -9.8</gravity>
+
+    <scene>
+      <ambient>0.45 0.45 0.45 1</ambient>
+      <background>0.75 0.78 0.82 1</background>
+      <shadows>true</shadows>
+      <grid>false</grid>
+    </scene>
+
+    <light name="main_light" type="directional">
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.6 0.6 0.6 1</diffuse>
+      <specular>0.4 0.4 0.4 1</specular>
+      <direction>-0.5 0.5 -1</direction>
+    </light>
+
+    <gui fullscreen="0">
+      <camera name="user_camera">
+        <pose>12 -10 8 0.7 0 1.15</pose>
+      </camera>
+    </gui>
+
+    <include>
+      <name>room_427_shell</name>
+      <uri>model://moein_room_427_shell</uri>
+      <pose>0 0 0 0 0 0</pose>
+    </include>
+
+
+    <include>
+      <name>light_z1_r1_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>1.80 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r1_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>1.80 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r1_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>1.80 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r1_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>1.80 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r2_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>3.00 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r2_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>3.00 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r2_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>3.00 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r2_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>3.00 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r3_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>4.20 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r3_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>4.20 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r3_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>4.20 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r3_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>4.20 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r4_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>5.40 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r4_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>5.40 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r4_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>5.40 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z1_r4_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>5.40 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r1_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>8.00 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r1_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>8.00 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r1_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>8.00 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r2_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>9.40 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r2_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>9.40 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r2_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>9.40 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r3_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>10.80 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r3_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>10.80 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r3_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>10.80 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r4_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>12.20 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r4_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>12.20 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z2_r4_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>12.20 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r1_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>14.20 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r1_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>14.20 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r1_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>14.20 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r1_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>14.20 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r2_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>15.40 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r2_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>15.40 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r2_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>15.40 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r2_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>15.40 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r3_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>16.60 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r3_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>16.60 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r3_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>16.60 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r3_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>16.60 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r4_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>17.80 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r4_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>17.80 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r4_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>17.80 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r4_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>17.80 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r5_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>19.00 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r5_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>19.00 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r5_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>19.00 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r5_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>19.00 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r6_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>20.20 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r6_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>20.20 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r6_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>20.20 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r6_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>20.20 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r7_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>21.40 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r7_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>21.40 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r7_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>21.40 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r7_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>21.40 5.55 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r8_c1</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>22.60 0.75 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r8_c2</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>22.60 2.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r8_c3</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>22.60 4.15 2.70 0 0 0</pose>
+    </include>
+
+    <include>
+      <name>light_z3_r8_c4</name>
+      <uri>model://moein_fluorescent_ceiling_light</uri>
+      <pose>22.60 5.55 2.70 0 0 0</pose>
+    </include>
+
+
+  </world>
+</sdf>


### PR DESCRIPTION
Adds a starter Gazebo world for Room 427.

Includes:
- measured room floor
- main walls
- 8 window openings with glass panes
- ceiling light panels
- Door 1, Door 2, and Door 3 panels
- connected 3-box wall section
- shiny dark floor material for reflection/glare testing

File added:
Projects/gazebo_demo/worlds/427.world