### PR TITLE
Add glossy black floor tile model for room 427

### DIFF
--- a/Projects/gazebo_demo/models/room_427_floor/model.config
+++ b/Projects/gazebo_demo/models/room_427_floor/model.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<model>
+  <name>room_427_floor</name>
+  <version>1.0</version>
+  <sdf version="1.10">model.sdf</sdf>
+  <description>Glossy black floor tile for room 427 (24.206 x 6.579 m)</description>
+</model>

--- a/Projects/gazebo_demo/models/room_427_floor/model.sdf
+++ b/Projects/gazebo_demo/models/room_427_floor/model.sdf
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<sdf version="1.10">
+  <model name="room_427_floor">
+    <static>true</static>
+    <link name="link">
+
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>24.206 6.579 0.01</size>
+          </box>
+        </geometry>
+      </collision>
+
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>24.206 6.579 0.01</size>
+          </box>
+        </geometry>
+        <material>
+          <ambient>0.02 0.02 0.02 1</ambient>
+          <diffuse>0.05 0.05 0.05 1</diffuse>
+          <specular>0.8 0.8 0.8 1</specular>
+          <pbr>
+            <metal>
+              <albedo>0.04 0.04 0.04 1</albedo>
+              <roughness_value>0.05</roughness_value>
+              <metalness_value>0.0</metalness_value>
+            </metal>
+          </pbr>
+        </material>
+      </visual>
+
+    </link>
+  </model>
+</sdf>


### PR DESCRIPTION
This PR adds a standalone Gazebo Sim model for the glossy black tiled floor of room 427.

The model is a single static entity sized to the exact dimensions of the room (24.206 x 6.579 m) 
with a PBR material configured for a glossy black ceramic appearance using the Ogre2 render engine.

Files added:
- Projects/gazebo_demo/models/room_427_floor/model.config
- Projects/gazebo_demo/models/room_427_floor/model.sdf